### PR TITLE
Setup fixes

### DIFF
--- a/nuPG.quark
+++ b/nuPG.quark
@@ -1,0 +1,11 @@
+(
+	\name: "nuPG",
+	\path: "nuPG_1.0",
+	\summary: "new Pulsar Generator",
+	\author: "Marcin Pietruszewski",
+	\version: 1.0,
+	\since: "2024",
+	\dependencies: [
+		"JITLibExtensions", "miSCellaneous",
+	]
+)

--- a/nuPG_24_startUp.scd
+++ b/nuPG_24_startUp.scd
@@ -8,6 +8,7 @@ s.makeWindow
 Server.default.options.recChannels_(~numChannels).recSampleFormat_("int24");
 Server.default.options.memSize = 192000 * 24;
 Server.default.options.numOutputBusChannels = 32;
+Server.default.options.numWireBufs = 256;
 
 s.waitForBoot({
 	//settable number of instances = number of pulsar streams

--- a/nuPG_24_startUp.scd
+++ b/nuPG_24_startUp.scd
@@ -1,3 +1,6 @@
+/*
+s.makeWindow
+*/
 (
 ~numChannels = 2;
 ~numberOfInstances = 3;
@@ -958,5 +961,3 @@ s.waitForBoot({
 		]);
 };})
 )
-
-s.makeWindow

--- a/nuPG_24_startUp.scd
+++ b/nuPG_24_startUp.scd
@@ -1,5 +1,8 @@
 /*
 s.makeWindow
+// expects screensize of ca. 1600x1024 or more
+// check screensize with:
+Window.screenBounds
 */
 (
 ~numChannels = 2;


### PR DESCRIPTION
This PR fixes some issues in the startup file: 
- removes an errorßinducing line
- sets server options to high enough numWireBufs
- adds screen size info

It also adds a basic quark info file. 